### PR TITLE
Add "test:ci" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "format": "prettier --check \"./**/*.{ts,tsx,js,css,json,md}\"",
         "format:fix": "prettier --write  \"./**/*.{ts,tsx,js,css,json,md}\"",
         "test": "jest --color --watch",
+        "test:ci": "jest --color --ci",
         "storybook": "start-storybook -p 6006 --quiet",
         "build-storybook": "build-storybook --output-dir storybook",
         "deploy-storybook": "storybook-to-ghpages --ci --out=storybook",


### PR DESCRIPTION
This lets you run tests without `--watch` an with `--ci`, which is more
appropriate for a CI environment like Jenkins, GitHub Actions, etc.

```
$ npm run test:ci

> webpack-react-spectrum@1.0.0 test:ci
> jest --color --ci

 PASS  src/components/App/App.test.tsx (6.567 s)
  ✓ App renders properly (73 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        7.806 s
Ran all test suites.
```