### PR TITLE
Make plopped component tests pass

### DIFF
--- a/templates/component.hbs
+++ b/templates/component.hbs
@@ -9,7 +9,7 @@ onClick?: VoidFunction;
 
 const {{name}}: FC<Props> = ({
     onClick,
-    text = "Welcome to Adobe Spectrum !",
+    text = "{{name}}",
     disabled = false,
     }) => {
     return (


### PR DESCRIPTION
Without this PR, if you plop a component and run the tests, they fail because the component's output (`Welcome to React Spectrum !`) and what the tests expect (the component name) don't match up:

```
$ plop component
? component name AnotherComponent
✔  pretty-add /src/components/AnotherComponent/index.tsx
✔  pretty-add /src/components/AnotherComponent/AnotherComponent.tsx
✔  pretty-add /src/components/AnotherComponent/AnotherComponent.test.tsx
✔  pretty-add /src/components/AnotherComponent/AnotherComponent.story.tsx

$ npm run test:ci

> webpack-react-spectrum@1.0.0 test:ci
> jest --color --ci

 PASS  src/components/App/App.test.tsx
 FAIL  src/components/AnotherComponent/AnotherComponent.test.tsx (6.084 s)
  ● AnotherComponent renders properly

    TestingLibraryElementError: Unable to find an element with the text: AnotherComponent. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
...
```

With this PR, the tests pass by default:

```
$ npm run test:ci

> webpack-react-spectrum@1.0.0 test:ci
> jest --color --ci

 PASS  src/components/AnotherComponent/AnotherComponent.test.tsx
 PASS  src/components/App/App.test.tsx

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        3.681 s, estimated 6 s
Ran all test suites.
```