### PR TITLE
build: eliminate warning about jsxBracketSameLine

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -6,7 +6,6 @@ const config = {
     quoteProps: "consistent",
     jsxSingleQuote: false,
     trailingComma: "all",
-    jsxBracketSameLine: false,
     arrowParens: "avoid",
     endOfLine: "lf",
 };


### PR DESCRIPTION
Remove `jsxBracketSameLine` to fix this warning:

```
$ npm run format

> webpack-react-spectrum@1.0.0 format
> prettier --check "./**/*.{ts,tsx,js,css,json,md}"

Checking formatting...
[warn] jsxBracketSameLine is deprecated.
All matched files use Prettier code style!
```